### PR TITLE
feat(m365): Support Shared Access Signatures for Cross-Tenant Reporting

### DIFF
--- a/m365/README.adoc
+++ b/m365/README.adoc
@@ -97,7 +97,8 @@ Advanced::
 `create_app` (bool) [default=True]::: If true, the app will be created. If false, the app will be imported
 `prefix_override` (string) [default=None]::: Prefix for resource names. If null, one will be generated from app_name
 `input_storage_container_url` (string) [default=None]::: If not null, input container to read configs from (must give permissions to service account). Otherwise by default will create storage container. Expect an https url pointing to a container
-`output_storage_container_url` (string) [default=None]::: If not null, output container to put results in (must give permissions to service account). Otherwise by default will create storage container. Expect an https url pointing to a container
+`output_storage_container_url` (string) [default=None]::: If not null, output container to put results in (must give permissions to service account or use SAS). Otherwise by default will create storage container. Expect an https url pointing to a container
+`output_storage_container_sas` (string) [default=None]::: If not null, shared access signature token (query string) to use when writing results to the output storage container. Set this when the container is in an external tenant (the owner of that container will provide the value).
 `tenants_dir_path` (string) [default=./tenants]::: Relative path to directory containing tenant configuration files in yaml
 `container_registry` (object) [default={'server': 'ghcr.io'}]::: Credentials for logging into registry with container image
 `container_image` (string) [default=ghcr.io/cisagov/scubaconnect-m365:latest]::: Docker image to use for running ScubaGear.

--- a/m365/image/run_container.ps1
+++ b/m365/image/run_container.ps1
@@ -91,6 +91,9 @@ Foreach ($tenantConfig in $(Get-ChildItem 'input\')) {
 
         Write-Output "  Starting Upload"
         $OutPath = "$($Env:REPORT_OUTPUT)/$($ResultsFile.Name)"
+        if ($Env:REPORT_SAS -ne "") {
+            $OutPath += "?$($Env:REPORT_SAS)"
+        }
         .\azcopy copy $ResultsFile.FullName $OutPath --output-level essential
         if ($LASTEXITCODE -gt 0) {
             throw "Error transferring files"

--- a/m365/terraform/main.tf
+++ b/m365/terraform/main.tf
@@ -67,6 +67,7 @@ module "container" {
   subnet_ids                   = var.vnet == null ? null : [module.networking[0].aci_subnet_id]
   schedule_interval            = var.schedule_interval
   output_storage_container_url = var.output_storage_container_url
+  output_storage_container_sas = var.output_storage_container_sas
   input_storage_container_url  = var.input_storage_container_url
   contact_emails               = var.contact_emails
   log_analytics_workspace      = azurerm_log_analytics_workspace.monitor_law

--- a/m365/terraform/modules/container/main.tf
+++ b/m365/terraform/modules/container/main.tf
@@ -81,6 +81,9 @@ resource "azurerm_container_group" "aci" {
       "DEBUG_LOG"       = "false"
       "MI_PRINCIPAL_ID" = azurerm_user_assigned_identity.container_mi.principal_id
     }
+    secure_environment_variables = {
+      "REPORT_SAS"      = var.output_storage_container_sas != null ? var.output_storage_container_sas : ""
+    }
     dynamic "ports" {
       for_each = var.subnet_ids == null ? [] : [1]
       content {

--- a/m365/terraform/modules/container/variables.tf
+++ b/m365/terraform/modules/container/variables.tf
@@ -31,7 +31,14 @@ variable "input_storage_container_url" {
 variable "output_storage_container_url" {
   default     = null
   type        = string
-  description = "If not null, output container to put results in (must give permissions to service account). Otherwise by default will create storage container. Expect an https url pointing to a container"
+  description = "If not null, output container to put results in (must give permissions to service account or use SAS). Otherwise by default will create storage container. Expect an https url pointing to a container"
+}
+
+variable "output_storage_container_sas" {
+  default     = null
+  type        = string
+  description = "If not null, shared access signature token (query string) to use when writing results to the output storage container. Set this when the container is in an external tenant (the owner of that container will provide the value)."
+  sensitive   = true
 }
 variable "tenants_dir_path" {
   default     = "./tenants"

--- a/m365/terraform/variables.tf
+++ b/m365/terraform/variables.tf
@@ -102,7 +102,14 @@ variable "input_storage_container_url" {
 variable "output_storage_container_url" {
   default     = null
   type        = string
-  description = "If not null, output container to put results in (must give permissions to service account). Otherwise by default will create storage container. Expect an https url pointing to a container"
+  description = "If not null, output container to put results in (must give permissions to service account or use SAS). Otherwise by default will create storage container. Expect an https url pointing to a container"
+}
+
+variable "output_storage_container_sas" {
+  default     = null
+  type        = string
+  description = "If not null, shared access signature token (query string) to use when writing results to the output storage container. Set this when the container is in an external tenant (the owner of that container will provide the value)."
+  sensitive   = true
 }
 
 variable "tenants_dir_path" {


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Introduces a new optional Terraform variable `output_storage_container_sas` to pass in a Shared Access Signature (SAS) token. When set, the SAS token will be used to authenticate to the output storage container when writing ScubaGear results. This is intended to be used when `output_storage_container_url` is set to a storage container in an external tenant.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

This provides additional flexibility when the ScubaConnect deployment and the output storage container are in different tenants. Authentication to the storage container currently relies on RBAC. This is automatically configured if Terraform deploys the storage container as part of ScubaConnect, but otherwise the owner of the storage container must grant access to the ScubaConnect service principal (requiring multi-tenant app consent). SAS tokens provide a less cumbersome and more tightly-scoped method to grant this access.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->

- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
