### PR TITLE
feat(m365): support secondary app for handling both Commercial/GCC High with single instance

### DIFF
--- a/m365/README.adoc
+++ b/m365/README.adoc
@@ -97,12 +97,14 @@ Advanced::
 `create_app` (bool) [default=True]::: If true, the app will be created. If false, the app will be imported
 `prefix_override` (string) [default=None]::: Prefix for resource names. If null, one will be generated from app_name
 `input_storage_container_url` (string) [default=None]::: If not null, input container to read configs from (must give permissions to service account). Otherwise by default will create storage container. Expect an https url pointing to a container
-`output_storage_container_url` (string) [default=None]::: If not null, output container to put results in (must give permissions to service account or use SAS). Otherwise by default will create storage container. Expect an https url pointing to a container
-`output_storage_container_sas` (string) [default=None]::: If not null, shared access signature token (query string) to use when writing results to the output storage container. Set this when the container is in an external tenant (the owner of that container will provide the value).
+`output_storage_container_url` (string) [default=None]::: If not null, output container to put results in (must give permissions to service account). Otherwise by default will create storage container. Expect an https url pointing to a container
 `tenants_dir_path` (string) [default=./tenants]::: Relative path to directory containing tenant configuration files in yaml
-`container_registry` (object) [default={'server': 'ghcr.io'}]::: Credentials for logging into registry with container image
+`container_registry` (object) [default=None]::: Credentials for logging into registry with container image
 `container_image` (string) [default=ghcr.io/cisagov/scubaconnect-m365:latest]::: Docker image to use for running ScubaGear.
 `container_memory_gb` (number) [default=3]::: Amount of memory to allocate for ScubaGear container. Due to memory leaks in some dependencies, this may need to be increased if running on many tenants
+`secondary_app_info` (object) [default=None]::: Information for a secondary app. This can be used for one ScubaConnect instance to handle multiple environments (e.g., GCC and GCC High).
+    To use, manually create an app in the other environment and add the certificate created for the primary app to it.
+    Set `environment_to_use` to the environment the manual app is in, either "commericial" or "gcchigh"
 
 [#onboard]
 === Onboarding a Tenant

--- a/m365/image/run_container.ps1
+++ b/m365/image/run_container.ps1
@@ -73,9 +73,9 @@ Foreach ($tenantConfig in $(Get-ChildItem 'input\')) {
         Write-Output "Running ScubaGear for $($tenantConfig.BaseName)"
 
         $params = @{
-            CertificateThumbPrint = $CertificateThumbPrint; # Certificate Hash; Needed for SP auth
-            AppID = $Env:APP_ID; # App ID; Needed for Service Principal Auth
-            Organization = $org; # primary domain of the tenantConfig needed for Service Principal Auth
+            CertificateThumbPrint = if ($null -ne $Env:SECONDARY_APP_ID -and $org.EndsWith($Env:SECONDARY_APP_TLD)) {$CertificateThumbPrintSecondary} else {$CertificateThumbPrint};
+            AppID = if ($null -ne $Env:SECONDARY_APP_ID -and $org.EndsWith($Env:SECONDARY_APP_TLD)) {$Env:SECONDARY_APP_ID} else {$Env:APP_ID}; 
+            Organization = $org;
             OutPath = ".\reports\$($org)"; # The folder path where the output will be stored
             OPAPath = "."
             ConfigFilePath = $tenantConfig.FullName
@@ -91,7 +91,7 @@ Foreach ($tenantConfig in $(Get-ChildItem 'input\')) {
 
         Write-Output "  Starting Upload"
         $OutPath = "$($Env:REPORT_OUTPUT)/$($ResultsFile.Name)"
-        if ($Env:REPORT_SAS -ne $null -and $Env:REPORT_SAS -ne "") {
+        if ($null -ne $Env:REPORT_SAS -and $Env:REPORT_SAS -ne "") {
             $OutPath += "?$($Env:REPORT_SAS)"
         }
         .\azcopy copy $ResultsFile.FullName $OutPath --output-level essential

--- a/m365/image/run_container.ps1
+++ b/m365/image/run_container.ps1
@@ -91,7 +91,7 @@ Foreach ($tenantConfig in $(Get-ChildItem 'input\')) {
 
         Write-Output "  Starting Upload"
         $OutPath = "$($Env:REPORT_OUTPUT)/$($ResultsFile.Name)"
-        if ($null -ne $Env:REPORT_SAS -and $Env:REPORT_SAS -ne "") {
+        if ($null -ne $Env:REPORT_SAS) {
             $OutPath += "?$($Env:REPORT_SAS)"
         }
         .\azcopy copy $ResultsFile.FullName $OutPath --output-level essential

--- a/m365/image/run_container.ps1
+++ b/m365/image/run_container.ps1
@@ -73,7 +73,7 @@ Foreach ($tenantConfig in $(Get-ChildItem 'input\')) {
         Write-Output "Running ScubaGear for $($tenantConfig.BaseName)"
 
         $params = @{
-            CertificateThumbPrint = if ($null -ne $Env:SECONDARY_APP_ID -and $org.EndsWith($Env:SECONDARY_APP_TLD)) {$CertificateThumbPrintSecondary} else {$CertificateThumbPrint};
+            CertificateThumbPrint = $CertificateThumbPrint;
             AppID = if ($null -ne $Env:SECONDARY_APP_ID -and $org.EndsWith($Env:SECONDARY_APP_TLD)) {$Env:SECONDARY_APP_ID} else {$Env:APP_ID}; 
             Organization = $org;
             OutPath = ".\reports\$($org)"; # The folder path where the output will be stored

--- a/m365/terraform/env/example/main.tf
+++ b/m365/terraform/env/example/main.tf
@@ -15,4 +15,5 @@ module "scuba_connect" {
   input_storage_container_url  = var.input_storage_container_url
   output_storage_container_url = var.output_storage_container_url
   tags                         = var.tags
+  secondary_app_info           = var.secondary_app_info
 }

--- a/m365/terraform/env/example/variables.tf
+++ b/m365/terraform/env/example/variables.tf
@@ -136,3 +136,19 @@ variable "container_memory_gb" {
     error_message = "Container memory must be between 2GB and 16GB"
   }
 }
+variable "secondary_app_info" {
+  description = <<EOF
+    Information for a secondary app. This can be used for one ScubaConnect instance to handle multiple environments (e.g., GCC and GCC High).
+    To use, manually create an app in the other environment and add the certificate created for the primary app to it.
+    Set `environment_to_use` to the environment the manual app is in, either "commericial" or "gcchigh"
+  EOF
+  type = object({
+    app_id = string
+    environment_to_use = string
+  })
+  default = null
+  validation {
+    condition = var.secondary_app_info == null ? true : contains(["commercial", "gcchigh"], var.secondary_app_info.environment_to_use)
+    error_message = "Valid values for create_mode are (Default, PointInTimeRestore, Replica)"
+  }
+}

--- a/m365/terraform/main.tf
+++ b/m365/terraform/main.tf
@@ -74,4 +74,5 @@ module "container" {
   container_memory_gb          = var.container_memory_gb
   cert_info                    = module.app.cert_info
   depends_on                   = [azurerm_resource_group_policy_assignment.tagging_assignments]
+  secondary_app_info           = var.secondary_app_info
 }

--- a/m365/terraform/modules/app/variables.tf
+++ b/m365/terraform/modules/app/variables.tf
@@ -23,16 +23,6 @@ variable "contact_emails" {
   type        = list(string)
 }
 
-variable "certificate_rotation_period_days" {
-  type        = number
-  description = "How many days between when the certificate key should be rotated. Note: rotation requires running terraform"
-  default     = 30
-  validation {
-    condition     = var.certificate_rotation_period_days <= 60 && var.certificate_rotation_period_days >= 3
-    error_message = "Rotation period must be between 3 and 60 days"
-  }
-}
-
 variable "image_path" {
   type        = string
   description = "Path to image used for app logo. Displayed in Azure console on installed tenants. Only needed when create_app=true"

--- a/m365/terraform/modules/container/main.tf
+++ b/m365/terraform/modules/container/main.tf
@@ -85,7 +85,7 @@ resource "azurerm_container_group" "aci" {
       "SECONDARY_APP_TLD" = var.secondary_app_info == null ? null : (var.secondary_app_info.environment_to_use == "commercial" ? "com" : "us")
     }
     secure_environment_variables = {
-      "REPORT_SAS"      = var.output_storage_container_sas != null ? var.output_storage_container_sas : ""
+      "REPORT_SAS"      = var.output_storage_container_sas
     }
     dynamic "ports" {
       for_each = var.subnet_ids == null ? [] : [1]

--- a/m365/terraform/modules/container/main.tf
+++ b/m365/terraform/modules/container/main.tf
@@ -69,6 +69,7 @@ resource "azurerm_container_group" "aci" {
     cpu    = "1"
     memory = var.container_memory_gb
     environment_variables = {
+      "DEBUG_LOG"       = "false"
       "RUN_TYPE"        = each.key
       "TENANT_ID"       = data.azurerm_client_config.current.tenant_id
       "APP_ID"          = var.application_client_id
@@ -78,8 +79,10 @@ resource "azurerm_container_group" "aci" {
       "IS_GOV"          = local.is_us_gov
       "VAULT_NAME"      = var.cert_info.vault_name
       "CERT_NAME"       = var.cert_info.cert_name
-      "DEBUG_LOG"       = "false"
       "MI_PRINCIPAL_ID" = azurerm_user_assigned_identity.container_mi.principal_id
+
+      "SECONDARY_APP_ID" = var.secondary_app_info == null ? null : var.secondary_app_info.app_id
+      "SECONDARY_APP_TLD" = var.secondary_app_info == null ? null : (var.secondary_app_info.environment_to_use == "commercial" ? "com" : "us")
     }
     secure_environment_variables = {
       "REPORT_SAS"      = var.output_storage_container_sas != null ? var.output_storage_container_sas : ""

--- a/m365/terraform/modules/container/variables.tf
+++ b/m365/terraform/modules/container/variables.tf
@@ -107,9 +107,27 @@ variable "container_memory_gb" {
 }
 
 variable "cert_info" {
+  description = "Information for obtaining to app certificate"
   type = object({
     vault_id   = string
     vault_name = string
     cert_name  = string
   })
+}
+
+variable "secondary_app_info" {
+  description = <<EOF
+    Information for a secondary app. This can be used for one ScubaConnect instance to handle multiple environments (e.g., GCC and GCC High).
+    To use, manually create an app in the other environment and add the certificate created for the primary app to it.
+    Set `environment_to_use` to the environment the manual app is in, either "commericial" or "gcchigh"
+  EOF
+  type = object({
+    app_id = string
+    environment_to_use = string
+  })
+  default = null
+  validation {
+    condition = var.secondary_app_info == null ? true : contains(["commercial", "gcchigh"], var.secondary_app_info.environment_to_use)
+    error_message = "Valid values for create_mode are (Default, PointInTimeRestore, Replica)"
+  }
 }

--- a/m365/terraform/modules/container/variables.tf
+++ b/m365/terraform/modules/container/variables.tf
@@ -107,7 +107,7 @@ variable "container_memory_gb" {
 }
 
 variable "cert_info" {
-  description = "Information for obtaining to app certificate"
+  description = "Information for obtaining app certificate"
   type = object({
     vault_id   = string
     vault_name = string

--- a/m365/terraform/variables.tf
+++ b/m365/terraform/variables.tf
@@ -143,3 +143,20 @@ variable "container_memory_gb" {
     error_message = "Container memory must be between 2GB and 16GB"
   }
 }
+
+variable "secondary_app_info" {
+  description = <<EOF
+    Information for a secondary app. This can be used for one ScubaConnect instance to handle multiple environments (e.g., GCC and GCC High).
+    To use, manually create an app in the other environment and add the certificate created for the primary app to it.
+    Set `environment_to_use` to the environment the manual app is in, either "commericial" or "gcchigh"
+  EOF
+  type = object({
+    app_id = string
+    environment_to_use = string
+  })
+  default = null
+  validation {
+    condition = var.secondary_app_info == null ? true : contains(["commercial", "gcchigh"], var.secondary_app_info.environment_to_use)
+    error_message = "Valid values for create_mode are (Default, PointInTimeRestore, Replica)"
+  }
+}

--- a/utils/tf_vars_to_adoc.py
+++ b/utils/tf_vars_to_adoc.py
@@ -16,4 +16,4 @@ for v in d['variable']:
         t = "object"
     default = f"[default={v[name]['default']}]" if "default" in v[name] else ""
     desc = v[name]["description"]
-    print(f"`{name}` ({t}) {default}::: {desc}")
+    print(f"`{name}` ({t}) {default}::: {desc.strip()}")


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #
  <!-- Remember this title will end up as the merge commit subject -->

## 🗣 Description ##

* Adds variables and container support for a secondary application ID.
* Updates docs for variables
* Changes `REPORT_SAS` variable to be null if not set

## 💭 Motivation and context ##

This change allows a secondary app to be created manually and is intended to allow one instance of ScubaConnect to handle tenants in both Commercial/GCC and GCC High. 
For example, if ScubaConnect is hosted in GCC, an app can be manually made in GCC High and tied in so that the single ScubaConnect instance can run on tenants in any environment.



## 🧪 Testing ##

Created second app in GCC. Verified this application was used when `environment_to_use` was set to `commercial` and that the primary app was used when the variable was changed to `gcchigh`

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs may have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] PR targets the correct parent branch (e.g., main or release-name) for merge.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] Changes are sized such that they do not touch excessive number of files.
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] Related issues these changes resolve are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant repo and/or project documentation updated to reflect these changes.
- [x] All automated checks (e.g., linting, static analysis, unit/smoke tests) passed.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. This section is for the merge coordinator to complete. -->

- [ ] Feature branch deleted after merge to clean up repository.
- [ ] Verified that all checks pass on parent branch (e.g., main or release-name) after merge.
