### PR TITLE
fix(gws): skip managed folders for existing input buckets

### DIFF
--- a/gws/terraform/modules/scuba_runner/storage.tf
+++ b/gws/terraform/modules/scuba_runner/storage.tf
@@ -65,7 +65,7 @@ resource "google_storage_bucket_iam_member" "scuba_runner_input_storage_perms" {
 }
 
 resource "google_storage_bucket_object" "type_folder" {
-  for_each = toset(local.container_types)
+  for_each = var.input_bucket == null ? toset(local.container_types) : toset([])
   name     = "${each.key}/"
   content  = " " # content is ignored but should be non-empty
   bucket   = google_storage_bucket.input_bucket[0].name

--- a/gws/terraform/modules/scuba_runner/tests/input_storage.tftest.hcl
+++ b/gws/terraform/modules/scuba_runner/tests/input_storage.tftest.hcl
@@ -1,0 +1,98 @@
+# These plan-only tests use mocked providers and require no cloud credentials.
+mock_provider "google" {
+  mock_data "google_client_config" {
+    defaults = {
+      project = "test-project"
+      region  = "us-central1"
+    }
+  }
+}
+
+mock_provider "random" {}
+
+variables {
+  cron_schedule    = "0 0 * * *"
+  contact_emails   = []
+  tenants_dir_path = "../../env/example/tenants"
+}
+
+run "existing_input_managed_output" {
+  command = plan
+
+  variables {
+    input_bucket = "existing-input"
+  }
+
+  assert {
+    condition = (
+      length(google_storage_bucket.input_bucket) == 0 &&
+      length(google_storage_bucket_object.type_folder) == 0 &&
+      length(google_storage_bucket_object.tenants) == 0 &&
+      length(google_storage_bucket_iam_member.scuba_runner_input_storage_perms) == 0
+    )
+    error_message = "An existing input bucket must not create or manage input resources."
+  }
+
+  assert {
+    condition     = output.input_storage_bucket == "existing-input" && length(google_storage_bucket.output_bucket) == 1
+    error_message = "The provided input bucket and managed output bucket must both be retained."
+  }
+}
+
+run "existing_input_external_output" {
+  command = plan
+
+  variables {
+    input_bucket         = "existing-input"
+    create_output_bucket = false
+    extra_output_buckets = ["external-output"]
+  }
+
+  assert {
+    condition = (
+      length(google_storage_bucket.input_bucket) == 0 &&
+      length(google_storage_bucket.output_bucket) == 0 &&
+      length(google_storage_bucket.log_bucket) == 0 &&
+      length(google_storage_bucket_object.type_folder) == 0 &&
+      length(google_storage_bucket_object.tenants) == 0
+    )
+    error_message = "External storage must not create buckets or input objects."
+  }
+
+  assert {
+    condition     = output.input_storage_bucket == "existing-input" && tolist(output.output_storage_buckets) == tolist(["external-output"])
+    error_message = "External storage names must be passed through unchanged."
+  }
+}
+
+run "managed_input_managed_output" {
+  command = plan
+
+  assert {
+    condition = (
+      length(google_storage_bucket.input_bucket) == 1 &&
+      toset(keys(google_storage_bucket_object.type_folder)) == toset(["adhoc", "scheduled"]) &&
+      toset(keys(google_storage_bucket_object.tenants)) == toset(["adhoc/example.org.yaml", "scheduled/example.org.yaml"])
+    )
+    error_message = "Managed input storage must retain both folders and tenant uploads."
+  }
+}
+
+run "managed_input_external_output" {
+  command = plan
+
+  variables {
+    create_output_bucket = false
+    extra_output_buckets = ["external-output"]
+  }
+
+  assert {
+    condition = (
+      length(google_storage_bucket.input_bucket) == 1 &&
+      length(google_storage_bucket.output_bucket) == 0 &&
+      length(google_storage_bucket.log_bucket) == 1 &&
+      toset(keys(google_storage_bucket_object.type_folder)) == toset(["adhoc", "scheduled"])
+    )
+    error_message = "Managed input folders must not depend on output bucket creation."
+  }
+}


### PR DESCRIPTION
## Summary

Create the `adhoc/` and `scheduled/` input folder objects only when the module creates the input bucket. Supplying an existing `input_bucket` currently fails planning because those objects dereference an empty managed-bucket collection.

Fixes #39.

## Testing

- Four mocked, plan-only Terraform tests cover managed/external input and output combinations.
- All four pass with Google providers **7.36.0** and **8.2.0**, using Terraform 1.9.8.
- The existing-input test reproduces `Invalid index` before the fix.
- `terraform validate` and test-file formatting pass. No cloud resources were created.

Run from `gws/terraform/modules/scuba_runner` with Terraform 1.7+:

```sh
terraform init -backend=false
terraform test
```
