### PR TITLE
Reject GWS deployments without output storage

### DIFF
--- a/gws/terraform/env/example/provider.tf
+++ b/gws/terraform/env/example/provider.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.2.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/gws/terraform/modules/scuba_runner/main.tf
+++ b/gws/terraform/modules/scuba_runner/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = ">= 1.2.0"
+}
+
 data "google_client_config" "this" {}
 
 # SA
@@ -94,6 +98,13 @@ resource "google_cloud_run_v2_job" "scuba_runner" {
     }
   }
 
+  lifecycle {
+    precondition {
+      condition     = var.create_output_bucket || length(var.extra_output_buckets) > 0
+      error_message = "At least one output bucket is required. Enable create_output_bucket or provide extra_output_buckets."
+    }
+  }
+
   depends_on = [google_project_service.service, google_artifact_registry_repository.ghcr_remote_repo]
 }
 
@@ -103,7 +114,7 @@ resource "google_cloud_run_v2_job_iam_member" "scuba_runner_scheduler_run" {
   project = data.google_client_config.this.project
   role    = "roles/run.jobsExecutorWithOverrides"
   member  = "serviceAccount:${google_service_account.scuba_runner_service_account.email}"
-  name = google_cloud_run_v2_job.scuba_runner.name
+  name    = google_cloud_run_v2_job.scuba_runner.name
 }
 
 resource "google_cloud_scheduler_job" "scuba_run_scheduler" {

--- a/gws/terraform/modules/scuba_runner/tests/output_storage.tftest.hcl
+++ b/gws/terraform/modules/scuba_runner/tests/output_storage.tftest.hcl
@@ -1,0 +1,55 @@
+# Plan-only tests; no Google credentials or cloud resources required.
+mock_provider "google" {
+  mock_data "google_client_config" {
+    defaults = {
+      project = "test-project"
+      region  = "us-central1"
+    }
+  }
+}
+mock_provider "random" {}
+
+variables {
+  cron_schedule    = "0 0 * * *"
+  contact_emails   = []
+  tenants_dir_path = "../../env/example/tenants"
+}
+
+run "managed_output" {
+  command = plan
+  assert {
+    condition     = length(output.output_storage_buckets) == 1
+    error_message = "Default managed output must remain supported."
+  }
+}
+
+run "external_output" {
+  command = plan
+  variables {
+    create_output_bucket = false
+    extra_output_buckets = ["external-reports"]
+  }
+  assert {
+    condition     = tolist(output.output_storage_buckets) == tolist(["external-reports"])
+    error_message = "External-only output must remain supported."
+  }
+}
+
+run "managed_and_external_output" {
+  command = plan
+  variables {
+    extra_output_buckets = ["external-reports"]
+  }
+  assert {
+    condition     = length(output.output_storage_buckets) == 2
+    error_message = "Managed and external output must remain supported together."
+  }
+}
+
+run "missing_output" {
+  command = plan
+  variables {
+    create_output_bucket = false
+  }
+  expect_failures = [google_cloud_run_v2_job.scuba_runner]
+}


### PR DESCRIPTION
## Summary

Reject GWS plans that disable managed output storage without providing an external output bucket. The error explains how to configure a destination before deploying a job that would immediately fail at runtime.

Managed-only, external-only and combined output modes remain supported. Declare Terraform 1.2+ for the resource precondition and update the example's minimum version accordingly.

Fixes #41.

## Testing

- Four mocked plan tests pass with Google providers **7.36.0** and **8.2.0** on Terraform 1.9.8.
- The missing-output test fails on unchanged main because the invalid plan succeeds.
- `terraform validate` passes on Terraform **1.2.9** and **1.9.8**; changed module/test formatting passes.
- No cloud credentials or resources used.

Run tests with Terraform 1.7+ from `gws/terraform/modules/scuba_runner`:

```sh
terraform init -backend=false
terraform test
```
